### PR TITLE
cSqlServerConfig Resource

### DIFF
--- a/DSCResources/sysengkm_cSqlServerConfig/README.md
+++ b/DSCResources/sysengkm_cSqlServerConfig/README.md
@@ -29,6 +29,7 @@ Set MaxDegreeofParallelism to 4 on Default SQL Instance:
 			        }	
 
 EXAMPLE Config:
+
 	Configuration sqltest
 	{
 	Import-DscResource  -module cSqlPs

--- a/DSCResources/sysengkm_cSqlServerConfig/README.md
+++ b/DSCResources/sysengkm_cSqlServerConfig/README.md
@@ -1,0 +1,54 @@
+# cSqlPs
+Community fork of the xSqlPs Resource Module
+
+cSqlServerConfig USAGE:
+
+Set MaxMemory on Default SQL Instance to 2048MB:
+
+        cSqlServerConfig smallSQLDpeloy
+			        {
+				        SqlPropertyName = 'MaxServerMemory'
+				        SqlPropertyValue = '2048'
+			        }
+
+Set MaxMemory to 8192 on the TEST SQL Instance:
+
+        cSqlServerConfig mediumSQLDpeloy
+				{
+				        InstanceName = 'TEST'
+				        SqlPropertyName = 'MaxServerMemory'
+				        SqlPropertyValue = '8192'
+			        }
+
+Set MaxDegreeofParallelism to 4 on Default SQL Instance:
+
+        cSqlServerConfig mediumSQLDpeloy
+				{
+				        SqlPropertyName = 'MaxDegreeofParallelism'
+				        SqlPropertyValue = '4'
+			        }	
+
+EXAMPLE Config:
+	Configuration sqltest
+	{
+	Import-DscResource  -module cSqlPs
+
+		Node 'testsqlserver'
+		 {
+			
+			cSqlServerConfig maxmem2048
+				{
+					SqlPropertyName = 'MaxServerMemory'
+					SqlPropertyValue = '2048'
+				}
+			cSqlServerConfig maxdop4
+				{
+					SqlPropertyName = 'MaxDegreeofParallelism'
+					SqlPropertyValue = '4'
+				}
+		}
+	}
+
+	sqltest
+
+Start-DscConfiguration -Wait -Verbose -Path .\sqltest

--- a/DSCResources/sysengkm_cSqlServerConfig/sysengkm_cSqlServerConfig.psm1
+++ b/DSCResources/sysengkm_cSqlServerConfig/sysengkm_cSqlServerConfig.psm1
@@ -1,0 +1,108 @@
+
+# cSQLServerConfig: DSC resource to set Sql Server Configuration Values like MaxServerMemory, MaxDegreeofParallelism, etc.
+#
+
+
+#
+# The Get-TargetResource cmdlet.
+#
+function Get-TargetResource
+{
+    [OutputType([hashtable])]
+    param
+    (	
+	[parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $SqlPropertyName,
+		
+        [string] $InstanceName = "Default",
+                 
+        [string] $SqlPropertyValue = '0'
+
+        
+    )
+	if(!(Get-Module -ListAvailable -Name SQLPS))
+	{
+		Throw "Please ensure that SQLPS module is installed."
+	}
+	
+    	Import-Module SQLPS -DisableNameChecking;
+	$value=$(Get-Item sqlserver:\\sql\\localhost\\$InstanceName).Configuration.$SqlPropertyName.ConfigValue
+
+	$returnValue = @{
+        		InstanceName = $InstanceName
+			SqlPropertyName = $SqlPropertyName
+			SqlPropertyValue = $value
+    			}
+
+    return $returnValue
+}
+
+
+#
+# The Set-TargetResource cmdlet.
+#
+function Set-TargetResource
+{
+    param
+    (	
+        [string] $InstanceName = "Default",
+        
+	[parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $SqlPropertyName,
+
+        [parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $SqlPropertyValue
+
+    )	
+	# Check if SQLPS module is present 
+	if(!(Get-Module -ListAvailable -Name SQLPS))
+	{
+		Throw "Please ensure that SQLPS module is installed."
+	}
+	
+    Import-Module SQLPS -DisableNameChecking;
+	$(Get-Item sqlserver:\\sql\\localhost\\$InstanceName).Configuration.$SqlPropertyName.ConfigValue=$SqlPropertyValue;
+	$(Get-Item sqlserver:\\sql\\localhost\\$InstanceName).Alter()
+}
+
+#
+# The Test-TargetResource cmdlet.
+#
+function Test-TargetResource
+{
+    [OutputType([bool])]
+    param
+    (	
+        [string] $InstanceName = "Default",
+        
+	[parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $SqlPropertyName,
+
+        [parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $SqlPropertyValue
+    )
+	# Check if SQLPS module is present 
+	if(!(Get-Module -ListAvailable -Name SQLPS))
+	{
+		Throw "Please ensure that SQLPS module is installed."
+	}
+	
+   	Import-Module SQLPS -DisableNameChecking;
+   	If(($(Get-Item sqlserver:\\sql\\localhost\\$InstanceName).Configuration.$SqlPropertyName.ConfigValue -eq $SqlPropertyValue))  { $result =$true } else { $result = $false }
+   
+   	 return $result;
+	
+}
+
+
+
+
+Export-ModuleMember -Function *-TargetResource
+
+
+

--- a/DSCResources/sysengkm_cSqlServerConfig/sysengkm_cSqlServerConfig.schema.mof
+++ b/DSCResources/sysengkm_cSqlServerConfig/sysengkm_cSqlServerConfig.schema.mof
@@ -1,0 +1,16 @@
+#pragma namespace("\\\\.\\root\\microsoft\\windows\\DesiredStateConfiguration")
+
+[ClassVersion("1.0.1"), FriendlyName("cSqlServerConfig")] 
+class sysengkm_cSqlServerConfig : OMI_BaseResource
+{
+    [key, Description("The name of the sql property to set.")] string SqlPropertyName;
+
+    [Description("The name of sql instance.")] string InstanceName;
+
+    [write, Description("The value to set")] string SqlPropertyValue;
+
+
+};
+
+
+


### PR DESCRIPTION
Created a resource, cSqlServerConfig, to set configuration values of SQL Server. Server must have SQLPS module available.

Example of how this would be used:

    Node 'testsqlserver'
     {

        cSqlServerConfig maxmem2048
            {
                SqlPropertyName = 'MaxServerMemory'
                SqlPropertyValue = '2048'
            }
        cSqlServerConfig maxdop4
            {
                SqlPropertyName = 'MaxDegreeofParallelism'
                SqlPropertyValue = '4'
            }
    }